### PR TITLE
chore: Adapt to Sonatype Central Publisher Portal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Publish
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
-          OSSRH_USERNAME: ${{ secrets.SONATYPE_OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+          SONATYPE_PORTAL_USERNAME: ${{ secrets.SONATYPE_PORTAL_USERNAME }}
+          SONATYPE_PORTAL_PASSWORD: ${{ secrets.SONATYPE_PORTAL_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           GPG_SECRET_KEYS: ${{ secrets.PGP_PRIVATE_KEY }}
         run: |

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -5,15 +5,15 @@
 
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.OSSRH_USERNAME}</username>
-            <password>${env.OSSRH_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.SONATYPE_PORTAL_USERNAME}</username>
+            <password>${env.SONATYPE_PORTAL_PASSWORD}</password>
         </server>
     </servers>
 
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -88,27 +88,16 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <deploymentName>camel-archetype-dhis2</deploymentName>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.hisp.dhis.integration.camel</groupId>
     <artifactId>camel-archetype-dhis2</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>camel-archetype-dhis2</name>


### PR DESCRIPTION
This PR adapts the publishing service to Central Publisher Portal.

It does not modify the artifact version, please change it if needed before merging.
